### PR TITLE
Content width fix

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -163,7 +163,8 @@ pre {
     margin-right: auto;
     margin-left: auto;
     padding-right: $spacing-unit;
-    padding-left: $spacing-unit;
+   // padding-left: $spacing-unit;
+    padding-left: 22em;
     @extend %clearfix;
 
     @include media-query($on-laptop) {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -108,7 +108,7 @@
 }
 
 .footer-col-wrapper {
-    font-size: 15px;
+    font-size: 12px;
     color: $grey-color;
     margin-left: -$spacing-unit / 2;
     @extend %clearfix;

--- a/css/main.scss
+++ b/css/main.scss
@@ -65,7 +65,7 @@ $on-laptop:        800px;
 }
 @media (min-width: 48em) {
   .sidebar {
-    position: fixed;
+    position: relative;
     top: 0;
     left: 0;
     bottom: 0;


### PR DESCRIPTION
For small screens content was cutoff by the sidebar. That should be fixed.

Also I saw that the footer text would overlap (since it is 3 columns). It should not overlap so much because that text is now smaller.

Finally the sidebar is now fixed to the top of the page. On small screens the bottom was cutoff and it wasn't possible to scroll.
